### PR TITLE
Add minimal UI templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Archetype Quiz
 
-Discover how you approach AI in the workplace. Built for behavioral health professionals and organizational leaders.
+Discover how you approach AI in the workplace. Built with FastAPI and a lightweight front end.
 
 ## Features
 - 10-question assessment identifying AI workplace archetypes
@@ -10,14 +10,14 @@ Discover how you approach AI in the workplace. Built for behavioral health profe
 - Shareable individual results
 
 ## Archetypes
-Based on podcast research, identifying 7 workplace AI approaches:
-- **Pioneer**: Early adopters who see AI as adventure
-- **Analyst**: Data-driven, want ROI before acting
-- **Worrier**: Concerned about job security and change
-- **Guardian**: Prioritize ethics and risk management
-- **Traditionalist**: Prefer established methods
-- **Opportunist**: See AI as competitive advantage
-- **Humanitarian**: Focus on equity and team impact
+Based on podcast research, identifying seven workplace AI approaches:
+- **Pioneer** – early adopters who see AI as adventure
+- **Analyst** – data-driven, want ROI before acting
+- **Worrier** – concerned about job security and change
+- **Guardian** – prioritize ethics and risk management
+- **Traditionalist** – prefer established methods
+- **Opportunist** – see AI as competitive advantage
+- **Humanitarian** – focus on equity and team impact
 
 ## Quick Deploy
 ```bash
@@ -25,7 +25,12 @@ git clone https://github.com/yourusername/ai-archetype-quiz
 cd ai-archetype-quiz
 flyctl launch
 flyctl deploy
-Local Development
-bashpip install -r requirements.txt
+```
+
+### Local Development
+```bash
+pip install -r requirements.txt
 uvicorn main:app --reload
+```
+
 Built with FastAPI, deployed on Fly.io. Licensed under MIT.

--- a/static/style.css
+++ b/static/style.css
@@ -1,1 +1,17 @@
-
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f5f5f5;
+}
+.page { display: none; padding: 20px; }
+.page--active { display: block; }
+.progress-bar { width: 100%; background: #ddd; height: 8px; margin-bottom: 20px; }
+.progress-fill { background: #4ECDC4; height: 8px; width: 0%; }
+.answer-option { border: 1px solid #ccc; padding: 10px; margin-bottom: 8px; cursor: pointer; }
+.answer-option--selected { background: #4ECDC4; color: #fff; }
+.nav-buttons { margin-top: 20px; }
+.nav-buttons button { margin-right: 10px; }
+.notification { position: fixed; top: 10px; right: 10px; background: #4ECDC4; color: #fff; padding: 10px; border-radius: 4px; display:none; }
+.notification.show { display:block; }
+.loading-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255,255,255,0.8); display:flex; align-items:center; justify-content:center; }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,1 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Admin Dashboard</h1>
+    <p>Logged in as {{ user['email'] }}</p>
+    <p><a href="/admin/logout">Logout</a></p>
 
+    <h2>Overview</h2>
+    <ul>
+        <li>Total submissions: <span id="total-submissions"></span></li>
+        <li>Average completion time: <span id="average-time"></span></li>
+        <li>Most common archetype: <span id="most-common-type"></span></li>
+    </ul>
+
+    <div id="archetype-chart" class="chart"></div>
+
+    <h3>Recent Submissions</h3>
+    <div id="recent-submissions-list" class="table"></div>
+
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>AI Archetype Quiz</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div id="notification" class="notification"></div>
+    <div id="error-message" class="error-message"></div>
+    <div id="loading-overlay" class="loading-overlay" style="display:none;">
+        <div class="loading-text">Loading...</div>
+    </div>
 
+    <div id="landing-page" class="page page--active">
+        <h1>AI Archetype Quiz</h1>
+        <p>Discover how you approach AI in the workplace.</p>
+        <button id="start-quiz-btn">Start Quiz</button>
+        <button id="admin-nav-btn">Admin Login</button>
+    </div>
+
+    <div id="quiz-page" class="page">
+        <div class="progress-bar"><div id="progress-fill" class="progress-fill"></div></div>
+        <p>Question <span id="current-question"></span> of <span id="total-questions"></span></p>
+        <div id="question-text" class="question-text"></div>
+        <div id="answer-options" class="answers"></div>
+        <div class="nav-buttons">
+            <button id="prev-btn">Previous</button>
+            <button id="next-btn" disabled>Next</button>
+        </div>
+    </div>
+
+    <div id="results-page" class="page">
+        <h2>Your AI Archetype: <span id="primary-archetype-name"></span></h2>
+        <p id="primary-archetype-score"></p>
+        <p id="primary-archetype-description"></p>
+        <p id="primary-archetype-approach"></p>
+        <ul id="primary-archetype-characteristics"></ul>
+        <h3>Score Breakdown</h3>
+        <div id="score-breakdown" class="score-breakdown"></div>
+        <div class="nav-buttons">
+            <button id="retake-quiz-btn">Retake Quiz</button>
+            <button id="view-summary-btn">View Summary</button>
+            <button id="share-results-btn" style="display:none;">Share</button>
+        </div>
+    </div>
+
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,1 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Quiz Results</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Your AI Archetype Results</h1>
+    <h2>{{ primary_archetype }}</h2>
+    <p>{{ archetype_data.description }}</p>
+    <p>{{ archetype_data.approach }}</p>
+    <ul>
+    {% for char in archetype_data.characteristics %}
+        <li>{{ char }}</li>
+    {% endfor %}
+    </ul>
 
+    <h3>Score Breakdown</h3>
+    <ul>
+    {% for archetype, score in scores.items() %}
+        <li>{{ archetype }}: {{ score }}%</li>
+    {% endfor %}
+    </ul>
+    <p>Completed at: {{ completed_at }}</p>
+    <p><a href="/">Take the quiz again</a></p>
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,1 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Quiz Summary</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Quiz Summary</h1>
+    <p>Total submissions: {{ total_submissions }}</p>
+    <p>Submissions in last 7 days: {{ recent_count }}</p>
 
+    <table>
+        <thead>
+            <tr><th>Archetype</th><th>Count</th><th>Percentage</th></tr>
+        </thead>
+        <tbody>
+        {% for stat in stats %}
+            <tr>
+                <td>{{ stat.archetype }}</td>
+                <td>{{ stat.count }}</td>
+                <td>{{ stat.percentage }}%</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <p><a href="/">Back to quiz</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML templates to render quiz, results, summary and admin pages
- add basic styling for the front end
- clean up README with local dev instructions

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6842509dbe688333a5e1f4942a667667